### PR TITLE
Fix return code from non git-svn commands

### DIFF
--- a/git-svn.sh
+++ b/git-svn.sh
@@ -20,8 +20,8 @@ git() {
 
     # otherwise just pass through to git
     if [ -z "$_git_svn" ]; then
-        command git "$@"
         unset _root _git_svn
+        command git "$@"
         return $?
     fi
 
@@ -64,8 +64,8 @@ git() {
     unset _expanded
 
     if [ "$1" != "svn" ]; then
-        command git "$@"
         unset _root
+        command git "$@"
         return $?
     else
         shift;


### PR DESCRIPTION
For non git-svn commands it always returned 0 because the function was
returning the returncode of the following unset not of the git command
