### PR TITLE
Improve alias expansion

### DIFF
--- a/git-svn.sh
+++ b/git-svn.sh
@@ -31,14 +31,7 @@ git() {
     _param_1=$1
     export _param_1
 
-    _expanded="$( \
-        command git config --get-regexp alias | sed -e 's/^alias\.//' | while read -r _alias _git_cmd; do \
-            if [ "$_alias" = "$_param_1" ]; then \
-                echo "$_git_cmd"; \
-                break; \
-            fi; \
-        done \
-    )"
+    _expanded="$(command git config --get-regexp ^alias.$_param_1$ | sed -e 's/[^ ]* //')"
 
     unset _param_1
 
@@ -141,10 +134,10 @@ git() {
 
 # Copyright (c) 2013, Rafael Kitover
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
+#
 # Redistributions of source code must retain the above copyright notice, this
 # list of conditions and the following disclaimer.
 #


### PR DESCRIPTION
I was encountering an issue where the previous alias expansion method wasn't expanding my aliases in some cases, it seems to be due to the read command sometimes not splitting the aliases properly. The new method is more succinct and does not encounter this issue.